### PR TITLE
feat(node): default executor finish message with hook

### DIFF
--- a/fvm/src/executor/default.rs
+++ b/fvm/src/executor/default.rs
@@ -570,7 +570,7 @@ where
 
         if gas_sum != gas_cost {
             // Sanity check. This could be a fatal error.
-            return Err(anyhow!("Gas handling math is wrong"));
+            return Err(anyhow!("Txn gas fee hook invalid, expecting total {} but found {}", gas_cost, gas_sum));
         }
 
         Ok(ApplyRet {

--- a/fvm/src/executor/default.rs
+++ b/fvm/src/executor/default.rs
@@ -605,7 +605,7 @@ where
     }
 }
 
-fn default_gas_hook(
+pub fn default_gas_hook(
     sender_id: ActorID,
     _: &Receipt,
     gas_output: &GasOutputs,

--- a/fvm/src/executor/mod.rs
+++ b/fvm/src/executor/mod.rs
@@ -20,6 +20,8 @@ use crate::call_manager::Backtrace;
 use crate::trace::ExecutionTrace;
 use crate::Kernel;
 
+pub use default::{ExecutionOptions, TxnGasHook};
+
 /// An executor executes messages on the underlying machine/kernel. It's responsible for:
 ///
 /// 1. Validating messages (nonce, sender, etc).

--- a/fvm/src/executor/mod.rs
+++ b/fvm/src/executor/mod.rs
@@ -20,7 +20,7 @@ use crate::call_manager::Backtrace;
 use crate::trace::ExecutionTrace;
 use crate::Kernel;
 
-pub use default::{ExecutionOptions, TxnGasHook};
+pub use default::{default_gas_hook, ExecutionOptions, TxnGasHook};
 
 /// An executor executes messages on the underlying machine/kernel. It's responsible for:
 ///

--- a/fvm/src/gas/mod.rs
+++ b/fvm/src/gas/mod.rs
@@ -10,7 +10,7 @@ use anyhow::Context;
 use num_traits::Zero;
 
 pub use self::charge::GasCharge;
-pub(crate) use self::outputs::GasOutputs;
+pub use self::outputs::GasOutputs;
 pub use self::price_list::{price_list_by_network_version, PriceList, WasmGasPrices};
 pub use self::timer::{GasDuration, GasInstant, GasTimer};
 use crate::kernel::{ClassifyResult, ExecutionError, Result};

--- a/fvm/src/gas/outputs.rs
+++ b/fvm/src/gas/outputs.rs
@@ -4,7 +4,7 @@
 use fvm_shared::econ::TokenAmount;
 
 #[derive(Clone, Default)]
-pub(crate) struct GasOutputs {
+pub struct GasOutputs {
     pub base_fee_burn: TokenAmount,
     pub over_estimation_burn: TokenAmount,
     pub miner_penalty: TokenAmount,


### PR DESCRIPTION
This PR introduces `finish_message_with_hook` method that allows customisation on which actors receives the transaction gas fee, i.e. https://github.com/consensus-shipyard/ref-fvm/blob/579946fe430c771c98e8d63d464f5038ed66e2ad/fvm/src/executor/default.rs#L528.

This is implemented by introducing a gas processing hook with a newly added method: execute_with_options. This method takes a closure as the gas processing hook. At the end of the execution, finish_message is replaced with finish_message_with_hook instead that calls the hook.